### PR TITLE
checks if attached before ready

### DIFF
--- a/twitter-timeline.es6.js
+++ b/twitter-timeline.es6.js
@@ -55,7 +55,7 @@ class twitterTimeline {
     this._computeLibLink()
     this._computeUniqueId()
     if (this.$.loaderTwtt.isAttached) {
-      this.$.loaderTwtt.attached();
+      this.$.loaderTwtt.attached()
     }
   }
 

--- a/twitter-timeline.es6.js
+++ b/twitter-timeline.es6.js
@@ -54,6 +54,9 @@ class twitterTimeline {
   ready () {
     this._computeLibLink()
     this._computeUniqueId()
+    if (this.$.loaderTwtt.isAttached) {
+      this.$.loaderTwtt.attached();
+    }
   }
 
   /**

--- a/twitter-timeline.js
+++ b/twitter-timeline.js
@@ -1,23 +1,24 @@
-'use strict'
+'use strict';
 
-var _createClass = function () { function defineProperties (target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor) } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor } }()
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-function _classCallCheck (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function') } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-var Polymer = window.Polymer
-var CustomEvent = window.CustomEvent
+var Polymer = window.Polymer;
+var CustomEvent = window.CustomEvent;
 
 var twitterTimeline = function () {
-  function twitterTimeline () {
-    _classCallCheck(this, twitterTimeline)
+  function twitterTimeline() {
+    _classCallCheck(this, twitterTimeline);
   }
 
   _createClass(twitterTimeline, [{
     key: 'beforeRegister',
 
+
     // Element setup goes in beforeRegister instead of createdCallback.
-    value: function beforeRegister () {
-      this.is = 'twitter-timeline'
+    value: function beforeRegister() {
+      this.is = 'twitter-timeline';
 
       // Define the properties object in beforeRegister.
       this.properties = {
@@ -46,23 +47,26 @@ var twitterTimeline = function () {
          */
         size: {
           type: Object,
-          value: function value () {
+          value: function value() {
             return {
               width: '400',
               height: '400'
-            }
+            };
           }
         }
-      }
+      };
     }
 
     // onReady fill <lib-loader> component to load Ace.js from CDN
 
   }, {
     key: 'ready',
-    value: function ready () {
-      this._computeLibLink()
-      this._computeUniqueId()
+    value: function ready() {
+      this._computeLibLink();
+      this._computeUniqueId();
+      if (this.$.loaderTwtt.isAttached) {
+        this.$.loaderTwtt.attached();
+      }
     }
 
     /**
@@ -72,13 +76,13 @@ var twitterTimeline = function () {
 
   }, {
     key: 'loadTimeline',
-    value: function loadTimeline (widgetId) {
-      var _this = this
+    value: function loadTimeline(widgetId) {
+      var _this = this;
 
       // Destroy previous timeline
-      this.removeTimeline()
+      this.removeTimeline();
       // Check if the widget id is present
-      var widget = widgetId || this._checkForWidgetId()
+      var widget = widgetId || this._checkForWidgetId();
 
       if (widget) {
         this.Twtt.widgets.createTimeline(widget, this.$.timeline, {
@@ -90,13 +94,13 @@ var twitterTimeline = function () {
             detail: {
               loaded: true
             }
-          }))
-        })
-        return true
+          }));
+        });
+        return true;
       }
 
-      console.warn("WARNING: 'data-widget-id' is not defined ")
-      return false
+      console.warn("WARNING: 'data-widget-id' is not defined ");
+      return false;
     }
 
     /**
@@ -105,11 +109,11 @@ var twitterTimeline = function () {
 
   }, {
     key: 'removeTimeline',
-    value: function removeTimeline () {
+    value: function removeTimeline() {
       if (this.$.timeline.querySelector('iframe')) {
-        return this.$.timeline.removeChild(this.$.timeline.querySelector('iframe'))
+        return this.$.timeline.removeChild(this.$.timeline.querySelector('iframe'));
       }
-      return false
+      return false;
     }
 
     /** ===============
@@ -118,37 +122,38 @@ var twitterTimeline = function () {
 
   }, {
     key: '_computeLibLink',
-    value: function _computeLibLink () {
-      this.$.loaderTwtt.set('lib', 'https://platform.twitter.com/widgets.js')
+    value: function _computeLibLink() {
+      this.$.loaderTwtt.set('lib', 'https://platform.twitter.com/widgets.js');
     }
   }, {
     key: '_computeUniqueId',
-    value: function _computeUniqueId () {
-      this.$.loaderTwtt.set('libUniqueId', this.uniqueId)
+    value: function _computeUniqueId() {
+      this.$.loaderTwtt.set('libUniqueId', this.uniqueId);
     }
   }, {
     key: '_checkForWidgetId',
-    value: function _checkForWidgetId () {
-      return this.dataWidgetId || false
+    value: function _checkForWidgetId() {
+      return this.dataWidgetId || false;
     }
   }, {
     key: '_onTwttLoad',
-    value: function _onTwttLoad () {
-      this.Twtt = window.twttr
-      this.loadTimeline()
+    value: function _onTwttLoad() {
+      this.Twtt = window.twttr;
+      this.loadTimeline();
     }
   }, {
     key: 'behaviors',
 
     // Define behaviors with a getter.
-    get: function get () {
-      return []
+    get: function get() {
+      return [];
     }
-  }])
+  }]);
 
-  return twitterTimeline
-}()
+  return twitterTimeline;
+}();
 
 // Register the element using Polymer's constructor.
 
-Polymer(twitterTimeline)
+
+Polymer(twitterTimeline);


### PR DESCRIPTION
There is no guarantee in Polymer that the `ready` function will be called before `lib-loader`'s `attached` function. This checks if the `lib-loader` has been attached before `ready` is called and calls `lib-loader`'s `attached` function again.

Unfortunately, due to `lib-loader`'s implementation, its error warning will still be thrown.